### PR TITLE
ISSUE-3: readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 -    **with** clj-new [installed](https://github.com/seancorfield/clj-new) in user deps.edn (recommended)
 
 ```bash 
-clj -A:new clj-python <mydomain.myapp>
+clj -A:new clj-python <mydomain.myapp> # don't copy
 
-;; example
+# example
 clj -A:new clj-python appcompany.funapp
 ```
 
@@ -24,9 +24,9 @@ clj -A:new clj-python appcompany.funapp
 ```bash 
 clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
 -m clj-new.create \
-clj-python <mydomain.myapp>
+clj-python <mydomain.myapp> # don't copy
 
-;; example
+# example
 clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
 -m clj-new.create \
 clj-python appcompany.funapp

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ clj -A:new clj-python appcompany.funapp
    
 -   **without** clj-new installed in user deps.edn
    
-   syntax:
 ```bash 
 clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
 -m clj-new.create \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@
 
 ## Usage
 
-* Create from the latest stable template:
-
-
-
-* libpython-clj projects can now be created quickly in 2 ways:
+* libpython-clj projects can now be created quickly in 2 ways from the latest stable template:
 
     **with clj-new installed in user deps.edn**
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,10 @@
 
 -    **with clj-new installed in user deps.edn**
 
-    syntax:
 ```bash 
     clj -A:new clj-python <mydomain.myapp>
-```
-    example:
-```bash
+
+    ;; example
     clj -A:new clj-python appcompany.funapp
 ```
 
@@ -28,11 +26,9 @@
     clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
     -m clj-new.create \
     clj-python <mydomain.myapp>
-```
-    example:
-```bash 
+
+    ;; example
     clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
     -m clj-new.create \
     clj-python appcompany.funapp
 ```
-

--- a/README.md
+++ b/README.md
@@ -5,19 +5,38 @@
 
 ## Usage
 
+* Create from the latest stable template:
 
-* libpython-clj projects can now be created quickly with:
 
+
+* libpython-clj projects can now be created quickly in 2 ways:
+
+    **with clj-new installed in user deps.edn**
+
+    syntax:
 ```bash 
-
-    clj -A:new https://github.com/clj-python/clj-template <project.name>
+    clj -A:new clj-python <mydomain.myapp>
 ```
+    example:
+```bash
+    clj -A:new clj-python appcompany.funapp
+```
+
    **NOTE**: this assumes you have `clj-new` configured in you `~/.clojure/deps.edn`
    profile. If you do not, you can use the following:
    
+   **without clj-new installed in user deps.edn**
+   
+   syntax:
 ```bash 
-clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
+    clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
     -m clj-new.create \
-	https://github.com/clj-python/clj-template@e24f817a3e804239540b666f8d39f5938a434543 \
-	myname.myapp myname/myapp
+    clj-python <mydomain.myapp>
 ```
+    example:
+```bash 
+    clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
+    -m clj-new.create \
+    clj-python appcompany.funapp
+```
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 #### libpython-clj projects can now be created quickly in 2 ways from the latest stable template:
 
--    **with** clj-new [installed](https://github.com/seancorfield/clj-new) in user deps.edn
+-    **with** clj-new [installed](https://github.com/seancorfield/clj-new) in user deps.edn (recommended)
 
 ```bash 
 clj -A:new clj-python <mydomain.myapp>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 #### libpython-clj projects can now be created quickly in 2 ways from the latest stable template:
 
--    **with clj-new installed in user deps.edn**
+-    **with** clj-new [installed](https://github.com/seancorfield/clj-new) in user deps.edn
 
 ```bash 
 clj -A:new clj-python <mydomain.myapp>
@@ -19,7 +19,7 @@ clj -A:new clj-python appcompany.funapp
    **NOTE**: this assumes you have `clj-new` configured in you `~/.clojure/deps.edn`
    profile. If you do not, you can use the following:
    
--   **without clj-new installed in user deps.edn**
+-   **without** clj-new installed in user deps.edn
    
    syntax:
 ```bash 
@@ -32,3 +32,7 @@ clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
 -m clj-new.create \
 clj-python appcompany.funapp
 ```
+
+For help please visit our [help-wanted](https://clojurians.zulipchat.com/#narrow/stream/215609-libpython-clj-dev/topic/help-wanted) topic.
+
+For configuration option requests, please file a Github issue or visit our [feature requests]( https://clojurians.zulipchat.com/#narrow/stream/215609-libpython-clj-dev/topic/feature-requests) topic.  

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## Usage
 
-* libpython-clj projects can now be created quickly in 2 ways from the latest stable template:
+#### libpython-clj projects can now be created quickly in 2 ways from the latest stable template:
 
-    **with clj-new installed in user deps.edn**
+-    **with clj-new installed in user deps.edn**
 
     syntax:
 ```bash 
@@ -21,7 +21,7 @@
    **NOTE**: this assumes you have `clj-new` configured in you `~/.clojure/deps.edn`
    profile. If you do not, you can use the following:
    
-   **without clj-new installed in user deps.edn**
+-   **without clj-new installed in user deps.edn**
    
    syntax:
 ```bash 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 -    **with clj-new installed in user deps.edn**
 
 ```bash 
-    clj -A:new clj-python <mydomain.myapp>
+clj -A:new clj-python <mydomain.myapp>
 
-    ;; example
-    clj -A:new clj-python appcompany.funapp
+;; example
+clj -A:new clj-python appcompany.funapp
 ```
 
    **NOTE**: this assumes you have `clj-new` configured in you `~/.clojure/deps.edn`
@@ -23,12 +23,12 @@
    
    syntax:
 ```bash 
-    clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
-    -m clj-new.create \
-    clj-python <mydomain.myapp>
+clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
+-m clj-new.create \
+clj-python <mydomain.myapp>
 
-    ;; example
-    clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
-    -m clj-new.create \
-    clj-python appcompany.funapp
+;; example
+clj -Sdeps '{:deps {seancorfield/clj-new {:mvn/version "0.8.6"}}}' \
+-m clj-new.create \
+clj-python appcompany.funapp
 ```


### PR DESCRIPTION
Closes: https://github.com/clj-python/clj-template/issues/3

Presupposes `6c9931a3ab5f6299c65653fd1396b1a47dcd19c7` is deployed to Clojars.

Visit https://github.com/jjtolton/clj-template/tree/ISSUE-3-readme-update to see what it looks like if changes requested.