### PR TITLE
Fix the incorrect library references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Libpython-clj clj-template
 
+* https://github.com/clj-python/libpython-clj
 * https://github.com/seancorfield/clj-new
 
 

--- a/src/clj/new/libpython_clj/core.clj
+++ b/src/clj/new/libpython_clj/core.clj
@@ -1,7 +1,7 @@
 (ns {{base}}.{{suffix}}
-    (:require [libpython-clj.python :as py :refer [py. py.- py.. py* py**]]
-              {{base}}.python
-              [libpython-clj.require :refer [require-python import-python]]))
+    (:require [libpython-clj2.python :as py :refer [py. py.- py.. py* py**]]
+              [{{base}}.python]
+              [libpython-clj2.require :refer [require-python import-python]]))
 
 (import-python)
 

--- a/src/clj/new/libpython_clj/python.clj
+++ b/src/clj/new/libpython_clj/python.clj
@@ -1,5 +1,5 @@
 (ns {{base}}.python
-    (:require [libpython-clj.python :as py]))
+    (:require [libpython-clj2.python :as py]))
 
 (defn initialize-python!
   ([] (py/initialize!))
@@ -11,5 +11,5 @@
 ;; you bind to below.  Make sure you do this before you call 'require-python'
 ;; in any file.
 
-;; (initialize-python! "/path/to/venv/bin/python")
-(initialize-python! "python3.7")
+;; (initialize-python! "/path/to/env/bin/python")
+(initialize-python! "python3")


### PR DESCRIPTION
Adds the `2` postfix to library references.
Use `python3` and not `python3.7` as executable. This will likely work for more environments
Added a link to the libpython-clj GitHub-page to the README